### PR TITLE
fixed missing metadata property

### DIFF
--- a/upcloud_api/server.py
+++ b/upcloud_api/server.py
@@ -325,6 +325,7 @@ class Server:
             'hostname': self.hostname,
             'zone': self.zone,
             'title': self.title,
+            'metadata': self.metadata,
             'storage_devices': {},
         }
 


### PR DESCRIPTION
This property needs to be set to 'yes' or else cloud-init based templates won't work. This commit adds this property to body so that it can be set correctly.